### PR TITLE
Changed Fragment Header, away from non-printables

### DIFF
--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -462,8 +462,8 @@ void LoRaAT::_createFragmentBuffer(char* message) {
     } header;
 
     //Create the header bytes
-    header.asByte[0] = _txPutter + 1;
-    header.asByte[1] = numFragments;
+    header.asByte[0] = _txPutter + 1 + _HEADER_OFFSET;
+    header.asByte[1] = numFragments + _HEADER_OFFSET;
 
     //Add the header to the byte array (delt with as a string)
     _txBuffer[_txPutter][0] = header.asChar[0];

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -61,6 +61,7 @@ class LoRaAT
 	static const uint8_t _PACKET_SIZE = 11;
 	static const uint8_t _HEADER_SIZE = 2;
 	static const uint8_t _PAYLOAD_SIZE = _PACKET_SIZE - _HEADER_SIZE;
+	static const uint8_t _HEADER_OFFSET = 48;
     
 	static const uint8_t _MAX_PAIRS_SIZE = 100;
     


### PR DESCRIPTION
Changed where the fragment header starts to aviod non-printable ASCII
characters which can cause problems with sending commands to the mDot
