### PR TITLE
Getters & Setters

### DIFF
--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -155,25 +155,40 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
         _response[_length++] = ATSerial->read();
 	  }
     }
-	
+  
     if (strstr(_response, ans1) != '\0') {
-	  if (resp != NULL) {
+      if (resp != NULL) {
         *resp = strstr(_response,command);
-		*resp += strlen(command);
-		*resp += sizeof(TERMINATOR);             //3
-	  }
+        *resp += strlen(command);
+        *resp += sizeof(TERMINATOR);               //3
+      }
       return (1);
     }
 	
     if (strstr(_response, ans2) != '\0') {
+      if (resp != NULL) {
+        *resp = strstr(_response,command);
+        *resp += strlen(command);
+        *resp += sizeof(TERMINATOR);               //3
+      }
       return (2);
     }
 	
     if (strstr(_response, ans3) != '\0') {
+      if (resp != NULL) {
+        *resp = strstr(_response,command);
+        *resp += strlen(command);
+        *resp += sizeof(TERMINATOR);               //3
+      }
       return (3);
     }
 	
     if (strstr(_response, ans4) != '\0') {
+      if (resp != NULL) {
+        *resp = strstr(_response,command);
+        *resp += strlen(command);
+        *resp += sizeof(TERMINATOR);               //3
+      }
       return (4);
     }
 	

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -544,7 +544,7 @@ int LoRaAT::setFrequencySubBand(char fsb) {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
-	//TODO: set the FSB public member
+	frequencySubBand = fsb;
     return (0);
   }
   
@@ -563,6 +563,8 @@ int LoRaAT::getFrequencySubBand() {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//We know AT+FSB? is echoed, then a <CR><LF>. So 9 characters
+	frequencySubBand = _response[10];
 	//TODO: Look in _response for FSB and set a public member
     return (0);
   }

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -166,6 +166,8 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
       _debugStream->print(F("LaT:sc: MEMLOC: "));
 	  if (resp != NULL) {
         *resp = strstr(_response,command);
+		*resp += strlen(command);
+		*resp += sizeof(TERMINATOR);             //3
 	  }
 	  if (*resp != NULL) {
 		_debugStream->println((int)*resp);

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -542,6 +542,7 @@ int LoRaAT::setFrequencySubBand(char fsb) {
   _command[8] = '\0';
 
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	frequencySubBand = fsb;
@@ -561,11 +562,11 @@ int LoRaAT::getFrequencySubBand() {
   sprintf_P(_command,(char*)F("AT+FSB?"));
 
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
-
+  ///_debugStream->println(_response);
+  
   if (ansCode == 1) {
-	//We know AT+FSB? is echoed, then a <CR><LF>. So 9 characters
+	//AT+FSB?<CR><LF><FSB>
 	frequencySubBand = _response[10];
-	//TODO: Look in _response for FSB and set a public member
     return (0);
   }
   
@@ -592,9 +593,10 @@ int LoRaAT::setPublicNetwork(char pn) {
   _command[7] = '\0';
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
-	//TODO: Set the PN public member
+	publicNetwork = pn;
     return (0);
   }
   
@@ -611,9 +613,11 @@ int LoRaAT::getPublicNetwork() {
   sprintf_P(_command,(char*)F("AT+PN?"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
-	//TODO: Look in _response for PN and set a public member
+    //AT+PN?<CR><LF><FSB>
+    publicNetwork = _response[9];
     return (0);
   }
   
@@ -638,9 +642,11 @@ int LoRaAT::setNetworkID(char* id) {
   strcat(_command,id);                           //Append ID to command
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
-	//TODO: set the NI public member
+	strncpy(networkId,id,sizeof(networkId)-1);
+	networkId[23] = '\0';
     return (0);
   }
   
@@ -657,9 +663,12 @@ int LoRaAT::getNetworkID() {
   sprintf_P(_command,(char*)F("AT+NI?"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
-	//TODO: Look in _response for NI and set a public member
+	char* ptr = &_response[9];
+	strncpy(networkId,ptr,sizeof(networkId)-1);
+	networkId[23] = '\0';
     return (0);
   }
   
@@ -684,6 +693,7 @@ int LoRaAT::setNetworkKey(char* key) {
   strcat(_command,key);                          //Append key to command
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	//TODO: set the NK public member
@@ -703,6 +713,7 @@ int LoRaAT::getNetworkKey() {
   sprintf_P(_command,(char*)F("AT+NK?"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	//TODO: Look in _response for NK and set a public member
@@ -727,6 +738,7 @@ int LoRaAT::setDataRate(char txdr) {
   _command[10] = '\0';
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	//TODO: set the txdr public member
@@ -746,6 +758,7 @@ int LoRaAT::getDataRate() {
   sprintf_P(_command,(char*)F("AT+TXDR?"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	//TODO: Look in _response for TXDR and set the public member
@@ -765,6 +778,7 @@ int LoRaAT::commitSettings() {
   sprintf_P(_command,(char*)F("AT&W"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
     return (0);

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -130,9 +130,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
   unsigned long maxEndTime = 0;
 
   //flush receive buffer before transmitting request
-  delay(200);
   while (ATSerial->read() != -1);
-  delay(200);
   
   //Blank string
   memset(_response,0x00,_MAX_MDOT_RESPONSE);

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -123,7 +123,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 | once a recognised response is received it returns the corresponding interger,     |
 | if no recognised response is recieved in the timout specified return 0.           |
 -----------------------------------------------------------------------------------*/
-uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, char* ans4, uint16_t timeout, char* resp) {
+uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, char* ans4, uint16_t timeout, char** resp) {
   ///_debugStream->println(F("LaT:sc: enter"));
   static const char TERMINATOR[3] = {'\r','\n','\0'};
    
@@ -152,7 +152,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
   
   //While something is available get it
   ///_debugStream->println(F("LaT:sc: Loop collecting response"));
-  resp = NULL;
+  *resp = NULL;
   do {
     if (ATSerial->available() != 0) {
 	  if (_length < (_MAX_MDOT_RESPONSE - 1)) {
@@ -166,9 +166,11 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
       _debugStream->print(F("LaT:sc: MEMLOC: "));
 	  _debugStream->println((int)strstr(_response,command));
       _debugStream->print(F("LaT:sc: MEMLOC: "));
-      resp = strstr(_response,command);
 	  if (resp != NULL) {
-		_debugStream->println((int)resp);
+        *resp = strstr(_response,command);
+	  }
+	  if (*resp != NULL) {
+		_debugStream->println((int)*resp);
 	  } else {
 		_debugStream->println("NULL");
 	  }
@@ -585,15 +587,18 @@ int LoRaAT::setFrequencySubBand(char fsb) {
 int LoRaAT::getFrequencySubBand() {
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
+  char* r;
   
   sprintf_P(_command,(char*)F("AT+FSB?"));
 
-  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
   ///_debugStream->println(_response);
+  _debugStream->print(F("LaT:sc: MEMLOC: "));
+  _debugStream->println((int)r);
   
   if (ansCode == 1) {
 	//AT+FSB?<CR><LF><FSB>
-	frequencySubBand = _response[10];
+	frequencySubBand = r[0];
     return (0);
   }
   
@@ -636,15 +641,16 @@ int LoRaAT::setPublicNetwork(char pn) {
 int LoRaAT::getPublicNetwork() {
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
+  char* r;
   
   sprintf_P(_command,(char*)F("AT+PN?"));
   
-  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
   ///_debugStream->println(_response);
 
   if (ansCode == 1) {
     //AT+PN?<CR><LF><FSB>
-    publicNetwork = _response[9];
+    publicNetwork = r[0];
     return (0);
   }
   
@@ -686,15 +692,15 @@ int LoRaAT::setNetworkID(char* id) {
 int LoRaAT::getNetworkID() {
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
+  char* r;
   
   sprintf_P(_command,(char*)F("AT+NI?"));
   
-  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
   ///_debugStream->println(_response);
 
   if (ansCode == 1) {
-	char* ptr = &_response[9];
-	strncpy(networkId,ptr,sizeof(networkId)-1);
+	strncpy(networkId,r,sizeof(networkId)-1);
 	networkId[23] = '\0';
     return (0);
   }
@@ -737,15 +743,15 @@ int LoRaAT::setNetworkKey(char* key) {
 int LoRaAT::getNetworkKey() {
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
+  char* r;
   
   sprintf_P(_command,(char*)F("AT+NK?"));
   
-  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
   ///_debugStream->println(_response);
 
   if (ansCode == 1) {
-	char* ptr = &_response[9];
-	strncpy(networkKey,ptr,(sizeof(networkKey)-1));
+	strncpy(networkKey,r,(sizeof(networkKey)-1));
 	networkKey[47] = '\0';
     return (0);
   }
@@ -784,14 +790,15 @@ int LoRaAT::setDataRate(char txdr) {
 int LoRaAT::getDataRate() {
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
+  char* r;
   
   sprintf_P(_command,(char*)F("AT+TXDR?"));
   
-  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
   ///_debugStream->println(_response);
 
   if (ansCode == 1) {
-	dataRate = _response[11];
+	dataRate = r[0];
     return (0);
   }
   

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -157,20 +157,10 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
     }
 	
     if (strstr(_response, ans1) != '\0') {
-      _debugStream->print(F("LaT:sc: MEMLOC: "));
-      _debugStream->println((int)_response);
-      _debugStream->print(F("LaT:sc: MEMLOC: "));
-	  _debugStream->println((int)strstr(_response,command));
-      _debugStream->print(F("LaT:sc: MEMLOC: "));
 	  if (resp != NULL) {
         *resp = strstr(_response,command);
 		*resp += strlen(command);
 		*resp += sizeof(TERMINATOR);             //3
-	  }
-	  if (*resp != NULL) {
-		_debugStream->println((int)*resp);
-	  } else {
-		_debugStream->println("NULL");
 	  }
       return (1);
     }
@@ -590,12 +580,8 @@ int LoRaAT::getFrequencySubBand() {
   sprintf_P(_command,(char*)F("AT+FSB?"));
 
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
-  ///_debugStream->println(_response);
-  _debugStream->print(F("LaT:sc: MEMLOC: "));
-  _debugStream->println((int)r);
   
   if (ansCode == 1) {
-	//AT+FSB?<CR><LF><FSB>
 	frequencySubBand = r[0];
     return (0);
   }
@@ -623,7 +609,6 @@ int LoRaAT::setPublicNetwork(char pn) {
   _command[7] = '\0';
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
-  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	publicNetwork = pn;
@@ -644,10 +629,8 @@ int LoRaAT::getPublicNetwork() {
   sprintf_P(_command,(char*)F("AT+PN?"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
-  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
-    //AT+PN?<CR><LF><FSB>
     publicNetwork = r[0];
     return (0);
   }
@@ -673,7 +656,6 @@ int LoRaAT::setNetworkID(char* id) {
   strcat(_command,id);                           //Append ID to command
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
-  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	strncpy(networkId,id,sizeof(networkId)-1);
@@ -695,7 +677,6 @@ int LoRaAT::getNetworkID() {
   sprintf_P(_command,(char*)F("AT+NI?"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
-  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	strncpy(networkId,r,sizeof(networkId)-1);
@@ -724,7 +705,6 @@ int LoRaAT::setNetworkKey(char* key) {
   strcat(_command,key);                          //Append key to command
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
-  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	strncpy(networkKey,key,sizeof(networkKey)-1);
@@ -746,7 +726,6 @@ int LoRaAT::getNetworkKey() {
   sprintf_P(_command,(char*)F("AT+NK?"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
-  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	strncpy(networkKey,r,(sizeof(networkKey)-1));
@@ -772,7 +751,6 @@ int LoRaAT::setDataRate(char txdr) {
   _command[10] = '\0';
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
-  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	dataRate = txdr;
@@ -793,7 +771,6 @@ int LoRaAT::getDataRate() {
   sprintf_P(_command,(char*)F("AT+TXDR?"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
-  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
 	dataRate = r[0];
@@ -813,7 +790,6 @@ int LoRaAT::commitSettings() {
   sprintf_P(_command,(char*)F("AT&W"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
-  ///_debugStream->println(_response);
 
   if (ansCode == 1) {
     return (0);

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -523,12 +523,14 @@ int LoRaAT::_processBuffer() {
   return(response);
 }
 
+
 /*----------------------------------------------------------------------------------|
 | Sets the frequency sub band                                                       |
 |                                                                                   |
+| AT+FSB ?                                                                          |
+| AT+FSB: (0-8)                                                                     |
+|                                                                                   |
 | TODO:                                                                             |
-|  * parse the response                                                             |
-|  * Return something meaningfull (based on response)                               |
 |  * Overload to accept, string, int, uint, byte, maybe others, maybe less.         |
 -----------------------------------------------------------------------------------*/
 int LoRaAT::setFrequencySubBand(char fsb) {
@@ -542,6 +544,7 @@ int LoRaAT::setFrequencySubBand(char fsb) {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: set the FSB public member
     return (0);
   }
   
@@ -550,10 +553,6 @@ int LoRaAT::setFrequencySubBand(char fsb) {
 
 /*----------------------------------------------------------------------------------|
 | Gets the frequency sub band                                                       |
-|                                                                                   |
-| TODO:                                                                             |
-|  * parse the response                                                             |
-|  * Return something meaningfull (based on response)                               |
 -----------------------------------------------------------------------------------*/
 int LoRaAT::getFrequencySubBand() {
   uint8_t ansCode;
@@ -564,6 +563,7 @@ int LoRaAT::getFrequencySubBand() {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: Look in _response for FSB and set a public member
     return (0);
   }
   
@@ -592,6 +592,7 @@ int LoRaAT::setPublicNetwork(char pn) {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: Set the PN public member
     return (0);
   }
   
@@ -600,10 +601,6 @@ int LoRaAT::setPublicNetwork(char pn) {
 
 /*----------------------------------------------------------------------------------|
 | Gets the public network                                                           |
-|                                                                                   |
-| TODO:                                                                             |
-|  * parse the response                                                             |
-|  * Return something meaningfull (based on response)                               |
 -----------------------------------------------------------------------------------*/
 int LoRaAT::getPublicNetwork() {
   uint8_t ansCode;
@@ -614,27 +611,12 @@ int LoRaAT::getPublicNetwork() {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: Look in _response for PN and set a public member
     return (0);
   }
   
   return(-1);
 }
-
-/*----------------------------------------------------------------------------------|
-| Sets the network ID                                                               |
-|                                                                                   |
-| AT+NI ?                                                                           |
-| AT+NI: (0,(hex:8)),(1,(string:128))                                               |
-|                                                                                   |
-| Examples:                                                                         |
-|  * AT+NI 0,00:00:aa:00:00:00:00:01                                                |
-|  * AT+NI 0,00-00-aa-00-00-00-00-01                                                |
------------------------------------------------------------------------------------*/
-/* int LoRaAT::setNetworkID(String id) {
-  char idc[24];
-  id.toCharArray(idc, 24);
-  LoRaAT::setNetworkID(idc);
-} */
 
 /*----------------------------------------------------------------------------------|
 | Sets the network ID                                                               |
@@ -656,6 +638,7 @@ int LoRaAT::setNetworkID(char* id) {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: set the NI public member
     return (0);
   }
   
@@ -664,10 +647,6 @@ int LoRaAT::setNetworkID(char* id) {
 
 /*----------------------------------------------------------------------------------|
 | Gets the network ID                                                               |
-|                                                                                   |
-| TODO:                                                                             |
-|  * parse the response                                                             |
-|  * Return something meaningfull (based on response)                               |
 -----------------------------------------------------------------------------------*/
 int LoRaAT::getNetworkID() {
   uint8_t ansCode;
@@ -678,27 +657,12 @@ int LoRaAT::getNetworkID() {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: Look in _response for NI and set a public member
     return (0);
   }
   
   return(-1);
 }
-
-/*----------------------------------------------------------------------------------|
-| Sets the network key                                                              |
-|                                                                                   |
-| AT+NK ?                                                                           |
-| AT+NK: (0,(hex:8)),(1,(string:128))                                               |
-|                                                                                   |
-| Examples:                                                                         |
-|  * AT+NK 0,00:00:aa:00:00:00:00:01                                                |
-|  * AT+NK 0,00-00-aa-00-00-00-00-01                                                |
------------------------------------------------------------------------------------*/
-/* int LoRaAT::setNetworkKey(String key) {
-  char keyc[48];
-  key.toCharArray(keyc, 48);
-  LoRaAT::setNetworkID(keyc);
-} */
 
 /*----------------------------------------------------------------------------------|
 | Sets the network key                                                              |
@@ -720,6 +684,7 @@ int LoRaAT::setNetworkKey(char* key) {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: set the NK public member
     return (0);
   }
   
@@ -728,10 +693,6 @@ int LoRaAT::setNetworkKey(char* key) {
 
 /*----------------------------------------------------------------------------------|
 | Gets the network key                                                              |
-|                                                                                   |
-| TODO:                                                                             |
-|  * parse the response                                                             |
-|  * Return something meaningfull (based on response)                               |
 -----------------------------------------------------------------------------------*/
 int LoRaAT::getNetworkKey() {
   uint8_t ansCode;
@@ -742,6 +703,7 @@ int LoRaAT::getNetworkKey() {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: Look in _response for NK and set a public member
     return (0);
   }
   
@@ -761,10 +723,6 @@ int LoRaAT::setDataRate() {
 
 /*----------------------------------------------------------------------------------|
 | Gets the data rate                                                                |
-|                                                                                   |
-| TODO:                                                                             |
-|  * parse the response                                                             |
-|  * Return something meaningfull (based on response)                               |
 -----------------------------------------------------------------------------------*/
 int LoRaAT::getDataRate() {
   uint8_t ansCode;
@@ -775,6 +733,7 @@ int LoRaAT::getDataRate() {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: Look in _response for DR and ADR and set the public members
     return (0);
   }
   
@@ -784,17 +743,13 @@ int LoRaAT::getDataRate() {
 /*----------------------------------------------------------------------------------|
 | Sets the ???                                                                      |
 -----------------------------------------------------------------------------------*/
-int LoRaAT::setRXOutput() {
+int LoRaAT::setRXOutput(uint8_t rxo) {
 
   return(0);
 }
 
 /*----------------------------------------------------------------------------------|
 | Gets the ???                                                                      |
-|                                                                                   |
-| TODO:                                                                             |
-|  * parse the response                                                             |
-|  * Return something meaningfull (based on response)                               |
 -----------------------------------------------------------------------------------*/
 int LoRaAT::getRXOutput() {
   uint8_t ansCode;
@@ -805,6 +760,7 @@ int LoRaAT::getRXOutput() {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
+	//TODO: Look in _response for RXO and set a public member
     return (0);
   }
   
@@ -815,6 +771,16 @@ int LoRaAT::getRXOutput() {
 | Writes the current settings of the mDot to it's memory                            |
 -----------------------------------------------------------------------------------*/
 int LoRaAT::commitSettings() {
+  uint8_t ansCode;
+  char ans1[] PROGMEM = "OK";
+  
+  sprintf_P(_command,(char*)F("AT&W"));
+  
+  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
-  return(0);
+  if (ansCode == 1) {
+    return (0);
+  }
+  
+  return(-1);
 }

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -125,7 +125,6 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 -----------------------------------------------------------------------------------*/
 uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, char* ans4, uint16_t timeout, char* resp) {
   ///_debugStream->println(F("LaT:sc: enter"));
-  //char* resp;
   static const char TERMINATOR[3] = {'\r','\n','\0'};
    
   unsigned long maxEndTime = 0;
@@ -141,10 +140,12 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
   
   //Send command
   _debugStream->print(F("LaT:sc: "));
-  _debugStream->print(command);
-  _debugStream->print(TERMINATOR);
-  ATSerial->print(command);
-  ATSerial->print(TERMINATOR);
+  _debugStream->println(command);
+  //_debugStream->print(command);
+  //_debugStream->print(TERMINATOR);
+  ATSerial->println(command);
+  //ATSerial->print(command);
+  //ATSerial->print(TERMINATOR);
   
   //Set timeout time
   maxEndTime = millis() + timeout;
@@ -159,23 +160,13 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 	  }
     }
 	
-	//if (resp = strstr(_response,command)) {
-      //resp += strlen(command)+strlen(TERMINATOR) + 3;
-    //}
-	
-	//char* resp = (char*)strstr(_response,command);
-	//resp = _response;
-	//_find(_response,command,resp);
-	
     if (strstr(_response, ans1) != '\0') {
-      resp = strstr(_response,command);
-      _debugStream->print(F("LaT:sc: MEMLOC: "));
-      _debugStream->println((int)ans1);
       _debugStream->print(F("LaT:sc: MEMLOC: "));
       _debugStream->println((int)_response);
       _debugStream->print(F("LaT:sc: MEMLOC: "));
 	  _debugStream->println((int)strstr(_response,command));
       _debugStream->print(F("LaT:sc: MEMLOC: "));
+      resp = strstr(_response,command);
 	  if (resp != NULL) {
 		_debugStream->println((int)resp);
 	  } else {
@@ -824,28 +815,4 @@ int LoRaAT::commitSettings() {
   }
   
   return(-1);
-}
-
-/*----------------------------------------------------------------------------------|
-| A simple find the substring function... Because strstr() didn't work how it was   |
-| expected in some instances.                                                       |
------------------------------------------------------------------------------------*/
-bool LoRaAT::_find(char* haystack, char* needle, char* ptr) {
-  int result;
-  _debugStream->print(F("LaT:F : MEMLOC: "));
-  _debugStream->println((int)haystack);
-  _debugStream->print(F("LaT:F : MEMLOC: "));
-  _debugStream->println((int)ptr);
-  ptr = haystack;
-  _debugStream->print(F("LaT:F : MEMLOC: "));
-  _debugStream->println((int)ptr);
-  if( sizeof(haystack) >= sizeof(needle)) {
-    for(uint16_t i = 0; i <= sizeof(haystack)-sizeof(needle); i++) {
-      result = memcmp(&haystack[i], needle, sizeof(needle) );	
-      if( result == 0 ) {
-        return true;
-      }
-    }
-  }
-  return false;
 }

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -116,7 +116,7 @@ void LoRaAT::begin(uint32_t u32BaudRate) {
 | if no recognised response is recieved in the timout specified return 0.           |
 -----------------------------------------------------------------------------------*/
 uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, char* ans4, uint16_t timeout) {
-  _sendCommand(command, ans1, ans2, ans3, ans4, timeout, NULL);
+  return _sendCommand(command, ans1, ans2, ans3, ans4, timeout, NULL);
 }
 /*----------------------------------------------------------------------------------|
 | the send command method, sends a command to the mDot and waits for a response.    |

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -123,8 +123,9 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 | once a recognised response is received it returns the corresponding interger,     |
 | if no recognised response is recieved in the timout specified return 0.           |
 -----------------------------------------------------------------------------------*/
-uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, char* ans4, uint16_t timeout, char * resp) {
+uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, char* ans4, uint16_t timeout, char* resp) {
   ///_debugStream->println(F("LaT:sc: enter"));
+  //char* resp;
   static const char TERMINATOR[3] = {'\r','\n','\0'};
    
   unsigned long maxEndTime = 0;
@@ -150,7 +151,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
   
   //While something is available get it
   ///_debugStream->println(F("LaT:sc: Loop collecting response"));
-  resp = 'A';
+  resp = NULL;
   do {
     if (ATSerial->available() != 0) {
 	  if (_length < (_MAX_MDOT_RESPONSE - 1)) {
@@ -158,13 +159,28 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 	  }
     }
 	
-	if (resp = strstr(_response,command)) {
-      resp += strlen(command)+strlen(TERMINATOR);
-    }
+	//if (resp = strstr(_response,command)) {
+      //resp += strlen(command)+strlen(TERMINATOR) + 3;
+    //}
+	
+	//char* resp = (char*)strstr(_response,command);
+	//resp = _response;
+	//_find(_response,command,resp);
 	
     if (strstr(_response, ans1) != '\0') {
-      _debugStream->print(F("LaT:sc: CHECK"));
-      _debugStream->println(resp);
+      resp = strstr(_response,command);
+      _debugStream->print(F("LaT:sc: MEMLOC: "));
+      _debugStream->println((int)ans1);
+      _debugStream->print(F("LaT:sc: MEMLOC: "));
+      _debugStream->println((int)_response);
+      _debugStream->print(F("LaT:sc: MEMLOC: "));
+	  _debugStream->println((int)strstr(_response,command));
+      _debugStream->print(F("LaT:sc: MEMLOC: "));
+	  if (resp != NULL) {
+		_debugStream->println((int)resp);
+	  } else {
+		_debugStream->println("NULL");
+	  }
       return (1);
     }
 	
@@ -201,7 +217,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 |                                                                                   |
 | uses a default of 10,000ms (10sec) timeout                                        |
 -----------------------------------------------------------------------------------*/
-int LoRaAT::join() {
+/*int LoRaAT::join() {
   return(join(10000));
 }
 
@@ -221,7 +237,7 @@ int LoRaAT::join() {
 | takes the parameter timeout, which is the number of milliseconds you want it      |
 | to wait for a response.                                                           |
 -----------------------------------------------------------------------------------*/
-int LoRaAT::join(unsigned int timeout) {
+/*int LoRaAT::join(unsigned int timeout) {
   ///_debugStream->println(F("LaT:j : enter"));
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
@@ -240,7 +256,7 @@ int LoRaAT::join(unsigned int timeout) {
 /*----------------------------------------------------------------------------------|
 | Leave a LoRa(WAN?) network                                                        |
 -----------------------------------------------------------------------------------*/
-void LoRaAT::leave() {
+/*void LoRaAT::leave() {
   ///_debugStream->println(F("LaT:l: not implemented"));
 }
 
@@ -265,7 +281,7 @@ void LoRaAT::leave() {
 |                                                                                   |
 | uses a default of 10,000ms (10sec) timeout                                        |
 -----------------------------------------------------------------------------------*/
-int LoRaAT::send(char* message) {
+/*int LoRaAT::send(char* message) {
   ///_debugStream->println(F("LaT:s : enter, w/ default timeout"));
   return(send(message,10000));
 }
@@ -289,7 +305,7 @@ int LoRaAT::send(char* message) {
 |      + Replace with something else?                                               |
 |      + Return error?                                                              |
 -----------------------------------------------------------------------------------*/
-int LoRaAT::send(char* message, unsigned int timeout) {
+/*int LoRaAT::send(char* message, unsigned int timeout) {
   ///_debugStream->println(F("LaT:s : enter"));
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
@@ -309,7 +325,7 @@ int LoRaAT::send(char* message, unsigned int timeout) {
 /*----------------------------------------------------------------------------------|
 | Not yet implemented.                                                              |
 -----------------------------------------------------------------------------------*/
-uint8_t LoRaAT::ping() {
+/*uint8_t LoRaAT::ping() {
   ///_debugStream->println(F("LaT:p: not implemented"));
 }
 
@@ -322,7 +338,7 @@ uint8_t LoRaAT::ping() {
 |                                                                                   |
 | //TODO: If not recieved in that format return an error                            |
 -----------------------------------------------------------------------------------*/
-int LoRaAT::sendPairs(String pairs) 
+/*int LoRaAT::sendPairs(String pairs) 
 {
   ///_debugStream->println(F("LaT:sp: enter"));
   char pairsC[_MAX_PAIRS_SIZE];
@@ -340,7 +356,7 @@ int LoRaAT::sendPairs(String pairs)
 |                                                                                   |
 | //TODO: If not recieved in that format return an error                            |
 -----------------------------------------------------------------------------------*/
-int LoRaAT::sendPairs(char* pairs) {
+/*int LoRaAT::sendPairs(char* pairs) {
   ///_debugStream->println(F("LaT:sp: enter"));
   ///_debugStream->println(F("LaT:sp: pairs:"));
   ///_debugStream->print(F("LaT:sp: "));
@@ -374,7 +390,7 @@ int LoRaAT::sendPairs(char* pairs) {
 | This function will take any correctly formatted char array of key:value pairs     |
 | and return a JSON formatted String.                                               |
 -----------------------------------------------------------------------------------*/
-void LoRaAT::_pairsToJSON(char* json, char* pairs) {
+/*void LoRaAT::_pairsToJSON(char* json, char* pairs) {
   ///_debugStream->println(F("LaT:pj: enter"));
   char* jsonPtr = json;
   char temp[20];
@@ -451,7 +467,7 @@ void LoRaAT::_pairsToJSON(char* json, char* pairs) {
 |                                                                                   |
 | header is of the format [fragment number][total number of fragments]              |
 -----------------------------------------------------------------------------------*/
-void LoRaAT::_createFragmentBuffer(char* message) {
+/*void LoRaAT::_createFragmentBuffer(char* message) {
   ///_debugStream->println(F("LaT:fb: enter"));
 
   int strLength = strlen(message);
@@ -514,7 +530,7 @@ void LoRaAT::_createFragmentBuffer(char* message) {
 /*----------------------------------------------------------------------------------|
 | Buffer processing function, which will send out all data currently in the buffer  |
 -----------------------------------------------------------------------------------*/
-int LoRaAT::_processBuffer() {
+/*int LoRaAT::_processBuffer() {
   char temp[_MAX_MDOT_COMMAND - 8];
   ///_debugStream->println(F("LaT:pb: enter"));
 
@@ -808,4 +824,28 @@ int LoRaAT::commitSettings() {
   }
   
   return(-1);
+}
+
+/*----------------------------------------------------------------------------------|
+| A simple find the substring function... Because strstr() didn't work how it was   |
+| expected in some instances.                                                       |
+-----------------------------------------------------------------------------------*/
+bool LoRaAT::_find(char* haystack, char* needle, char* ptr) {
+  int result;
+  _debugStream->print(F("LaT:F : MEMLOC: "));
+  _debugStream->println((int)haystack);
+  _debugStream->print(F("LaT:F : MEMLOC: "));
+  _debugStream->println((int)ptr);
+  ptr = haystack;
+  _debugStream->print(F("LaT:F : MEMLOC: "));
+  _debugStream->println((int)ptr);
+  if( sizeof(haystack) >= sizeof(needle)) {
+    for(uint16_t i = 0; i <= sizeof(haystack)-sizeof(needle); i++) {
+      result = memcmp(&haystack[i], needle, sizeof(needle) );	
+      if( result == 0 ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -715,11 +715,12 @@ int LoRaAT::getNetworkID() {
 int LoRaAT::setNetworkKey(char* key) {
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
+  char ansX[] PROGMEM = "BUG";
   
   sprintf_P(_command,(char*)F("AT+NK 0,"));
   strcat(_command,key);                          //Append key to command
   
-  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
+  ansCode = _sendCommand(_command,ans1,ansX,ansX,ansX,10000);
 
   if (ansCode == 1) {
 	strncpy(networkKey,key,sizeof(networkKey)-1);
@@ -736,12 +737,13 @@ int LoRaAT::setNetworkKey(char* key) {
 int LoRaAT::getNetworkKey() {
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
+  char ansX[] PROGMEM = "BUG";
   char* r;
   
   sprintf_P(_command,(char*)F("AT+NK?"));
   
-  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
-
+  ansCode = _sendCommand(_command,ans1,ansX,ansX,ansX,10000, &r);
+  
   if (ansCode == 1) {
 	strncpy(networkKey,r,(sizeof(networkKey)-1));
 	networkKey[47] = '\0';
@@ -788,7 +790,7 @@ int LoRaAT::getDataRate() {
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000, &r);
 
   if (ansCode == 1) {
-	dataRate = r[0];
+	dataRate = r[2];
     return (0);
   }
   

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -213,7 +213,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 |                                                                                   |
 | uses a default of 10,000ms (10sec) timeout                                        |
 -----------------------------------------------------------------------------------*/
-/*int LoRaAT::join() {
+int LoRaAT::join() {
   return(join(10000));
 }
 
@@ -233,7 +233,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 | takes the parameter timeout, which is the number of milliseconds you want it      |
 | to wait for a response.                                                           |
 -----------------------------------------------------------------------------------*/
-/*int LoRaAT::join(unsigned int timeout) {
+int LoRaAT::join(unsigned int timeout) {
   ///_debugStream->println(F("LaT:j : enter"));
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
@@ -252,7 +252,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 /*----------------------------------------------------------------------------------|
 | Leave a LoRa(WAN?) network                                                        |
 -----------------------------------------------------------------------------------*/
-/*void LoRaAT::leave() {
+void LoRaAT::leave() {
   ///_debugStream->println(F("LaT:l: not implemented"));
 }
 
@@ -277,7 +277,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 |                                                                                   |
 | uses a default of 10,000ms (10sec) timeout                                        |
 -----------------------------------------------------------------------------------*/
-/*int LoRaAT::send(char* message) {
+int LoRaAT::send(char* message) {
   ///_debugStream->println(F("LaT:s : enter, w/ default timeout"));
   return(send(message,10000));
 }
@@ -301,7 +301,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 |      + Replace with something else?                                               |
 |      + Return error?                                                              |
 -----------------------------------------------------------------------------------*/
-/*int LoRaAT::send(char* message, unsigned int timeout) {
+int LoRaAT::send(char* message, unsigned int timeout) {
   ///_debugStream->println(F("LaT:s : enter"));
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
@@ -321,7 +321,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 /*----------------------------------------------------------------------------------|
 | Not yet implemented.                                                              |
 -----------------------------------------------------------------------------------*/
-/*uint8_t LoRaAT::ping() {
+uint8_t LoRaAT::ping() {
   ///_debugStream->println(F("LaT:p: not implemented"));
 }
 
@@ -334,7 +334,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 |                                                                                   |
 | //TODO: If not recieved in that format return an error                            |
 -----------------------------------------------------------------------------------*/
-/*int LoRaAT::sendPairs(String pairs) 
+int LoRaAT::sendPairs(String pairs) 
 {
   ///_debugStream->println(F("LaT:sp: enter"));
   char pairsC[_MAX_PAIRS_SIZE];
@@ -352,7 +352,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 |                                                                                   |
 | //TODO: If not recieved in that format return an error                            |
 -----------------------------------------------------------------------------------*/
-/*int LoRaAT::sendPairs(char* pairs) {
+int LoRaAT::sendPairs(char* pairs) {
   ///_debugStream->println(F("LaT:sp: enter"));
   ///_debugStream->println(F("LaT:sp: pairs:"));
   ///_debugStream->print(F("LaT:sp: "));
@@ -386,7 +386,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 | This function will take any correctly formatted char array of key:value pairs     |
 | and return a JSON formatted String.                                               |
 -----------------------------------------------------------------------------------*/
-/*void LoRaAT::_pairsToJSON(char* json, char* pairs) {
+void LoRaAT::_pairsToJSON(char* json, char* pairs) {
   ///_debugStream->println(F("LaT:pj: enter"));
   char* jsonPtr = json;
   char temp[20];
@@ -463,7 +463,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 |                                                                                   |
 | header is of the format [fragment number][total number of fragments]              |
 -----------------------------------------------------------------------------------*/
-/*void LoRaAT::_createFragmentBuffer(char* message) {
+void LoRaAT::_createFragmentBuffer(char* message) {
   ///_debugStream->println(F("LaT:fb: enter"));
 
   int strLength = strlen(message);
@@ -526,7 +526,7 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
 /*----------------------------------------------------------------------------------|
 | Buffer processing function, which will send out all data currently in the buffer  |
 -----------------------------------------------------------------------------------*/
-/*int LoRaAT::_processBuffer() {
+int LoRaAT::_processBuffer() {
   char temp[_MAX_MDOT_COMMAND - 8];
   ///_debugStream->println(F("LaT:pb: enter"));
 

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -140,12 +140,10 @@ uint8_t LoRaAT::_sendCommand(char* command, char* ans1, char* ans2, char* ans3, 
   
   //Send command
   _debugStream->print(F("LaT:sc: "));
-  _debugStream->println(command);
-  //_debugStream->print(command);
-  //_debugStream->print(TERMINATOR);
-  ATSerial->println(command);
-  //ATSerial->print(command);
-  //ATSerial->print(TERMINATOR);
+  _debugStream->print(command);
+  _debugStream->print(TERMINATOR);
+  ATSerial->print(command);
+  ATSerial->print(TERMINATOR);
   
   //Set timeout time
   maxEndTime = millis() + timeout;

--- a/LoRaAT/LoRaAT.cpp
+++ b/LoRaAT/LoRaAT.cpp
@@ -713,12 +713,25 @@ int LoRaAT::getNetworkKey() {
 /*----------------------------------------------------------------------------------|
 | Sets the data rate                                                                |
 |                                                                                   |
-| this function can be used to set a specific data rate or set the data rate to     |
-| adaptive.                                                                         |
+| AT+TXDR ?                                                                         |
+| AT+TXDR: (0-3|10-7|DR0-DR4|DR8-DR13)                                              |
 -----------------------------------------------------------------------------------*/
-int LoRaAT::setDataRate() {
+int LoRaAT::setDataRate(char txdr) {
+  uint8_t ansCode;
+  char ans1[] PROGMEM = "OK";
+  
+  sprintf_P(_command,(char*)F("AT+TXDR "));
+  _command[9] = txdr;
+  _command[10] = '\0';
+  
+  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
-  return(0);
+  if (ansCode == 1) {
+	//TODO: set the txdr public member
+    return (0);
+  }
+  
+  return(-1);
 }
 
 /*----------------------------------------------------------------------------------|
@@ -728,39 +741,12 @@ int LoRaAT::getDataRate() {
   uint8_t ansCode;
   char ans1[] PROGMEM = "OK";
   
-  sprintf_P(_command,(char*)F("AT+ADR?"));
+  sprintf_P(_command,(char*)F("AT+TXDR?"));
   
   ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
 
   if (ansCode == 1) {
-	//TODO: Look in _response for DR and ADR and set the public members
-    return (0);
-  }
-  
-  return(-1);
-}
-
-/*----------------------------------------------------------------------------------|
-| Sets the ???                                                                      |
------------------------------------------------------------------------------------*/
-int LoRaAT::setRXOutput(uint8_t rxo) {
-
-  return(0);
-}
-
-/*----------------------------------------------------------------------------------|
-| Gets the ???                                                                      |
------------------------------------------------------------------------------------*/
-int LoRaAT::getRXOutput() {
-  uint8_t ansCode;
-  char ans1[] PROGMEM = "OK";
-  
-  sprintf_P(_command,(char*)F("AT+RXO?"));
-  
-  ansCode = _sendCommand(_command,ans1,NULL,NULL,NULL,10000);
-
-  if (ansCode == 1) {
-	//TODO: Look in _response for RXO and set a public member
+	//TODO: Look in _response for TXDR and set the public member
     return (0);
   }
   

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -36,15 +36,15 @@ class LoRaAT
 	void begin();			        //Use default baud
 	void begin(uint32_t);	        //Use specified baud rate.
 	
-	int join();				        //Join a LoRa network.
-	int join(unsigned int);         //Join with a specific timeout
-    void leave();			        //Leave a LoRa network, Not yet implemented
+	//int join();				        //Join a LoRa network.
+	//int join(unsigned int);         //Join with a specific timeout
+    //void leave();			        //Leave a LoRa network, Not yet implemented
 	
-	int send(char*);		        //Generic send command, using AT+SEND
-	int send(char*, unsigned int);  //Use specific timeout.
-	int sendPairs(char*);	        //Takes key,value pairs, forms a message, and sends to the LoRa server.
-    int sendPairs(String); 	        //Takes key,value pairs, forms a message, and sends to the LoRa server.
-	uint8_t ping();			        //Not yet implemented
+	//int send(char*);		        //Generic send command, using AT+SEND
+	//int send(char*, unsigned int);  //Use specific timeout.
+	//int sendPairs(char*);	        //Takes key,value pairs, forms a message, and sends to the LoRa server.
+    //int sendPairs(String); 	        //Takes key,value pairs, forms a message, and sends to the LoRa server.
+	//uint8_t ping();			        //Not yet implemented
 	
 	//Getter and setter functions for mDot Settings.
 	//NOT FULLY TESTED AND IMPLEMENTED
@@ -63,17 +63,17 @@ class LoRaAT
     int commitSettings();			//Not yet implemented
   
   private:
-	static const uint8_t _MAX_FRAGMENTS = 16;
-	static const uint8_t _PACKET_SIZE = 11;
-	static const uint8_t _HEADER_SIZE = 2;
-	static const uint8_t _PAYLOAD_SIZE = _PACKET_SIZE - _HEADER_SIZE;
-	static const uint8_t _HEADER_OFFSET = 48;
+	//static const uint8_t _MAX_FRAGMENTS = 16;
+	//static const uint8_t _PACKET_SIZE = 11;
+	//static const uint8_t _HEADER_SIZE = 2;
+	//static const uint8_t _PAYLOAD_SIZE = _PACKET_SIZE - _HEADER_SIZE;
+	//static const uint8_t _HEADER_OFFSET = 48;
     
-	static const uint8_t _MAX_PAIRS_SIZE = 100;
+	//static const uint8_t _MAX_PAIRS_SIZE = 100;
     
-	char _txBuffer[_MAX_FRAGMENTS][_PACKET_SIZE];
-	uint8_t _txPutter = 0;
-	uint8_t _txGetter = 0;
+	//char _txBuffer[_MAX_FRAGMENTS][_PACKET_SIZE];
+	//uint8_t _txPutter = 0;
+	//uint8_t _txGetter = 0;
 	
 	static const uint8_t _MAX_MDOT_RESPONSE = 150;			//Max number of bytes the mdot might return
 	char _response[_MAX_MDOT_RESPONSE];						//mDot response buffer
@@ -85,9 +85,11 @@ class LoRaAT
 	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t);
 	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t, char*);             //Generic serial out get response wrapper
 	
-	void _pairsToJSON(char*, char*);
-	void _createFragmentBuffer(char*);
-	int _processBuffer();
+	//void _pairsToJSON(char*, char*);
+	//void _createFragmentBuffer(char*);
+	//int _processBuffer();
+	
+	bool _find(char*, char*, char*);
 	
     uint8_t _u8SerialPort;                                 //AT Command serial port selection by user
 	Stream* _debugStream;                                  //Debugging serial port initialized in constructor

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -36,15 +36,15 @@ class LoRaAT
 	void begin();			        //Use default baud
 	void begin(uint32_t);	        //Use specified baud rate.
 	
-	//int join();				        //Join a LoRa network.
-	//int join(unsigned int);         //Join with a specific timeout
-    //void leave();			        //Leave a LoRa network, Not yet implemented
+	int join();				        //Join a LoRa network.
+	int join(unsigned int);         //Join with a specific timeout
+    void leave();			        //Leave a LoRa network, Not yet implemented
 	
-	//int send(char*);		        //Generic send command, using AT+SEND
-	//int send(char*, unsigned int);  //Use specific timeout.
-	//int sendPairs(char*);	        //Takes key,value pairs, forms a message, and sends to the LoRa server.
-    //int sendPairs(String); 	        //Takes key,value pairs, forms a message, and sends to the LoRa server.
-	//uint8_t ping();			        //Not yet implemented
+	int send(char*);		        //Generic send command, using AT+SEND
+	int send(char*, unsigned int);  //Use specific timeout.
+	int sendPairs(char*);	        //Takes key,value pairs, forms a message, and sends to the LoRa server.
+    int sendPairs(String); 	        //Takes key,value pairs, forms a message, and sends to the LoRa server.
+	uint8_t ping();			        //Not yet implemented
 	
 	//Getter and setter functions for mDot Settings.
 	//NOT FULLY TESTED AND IMPLEMENTED
@@ -63,17 +63,17 @@ class LoRaAT
     int commitSettings();			//Not yet implemented
   
   private:
-	//static const uint8_t _MAX_FRAGMENTS = 16;
-	//static const uint8_t _PACKET_SIZE = 11;
-	//static const uint8_t _HEADER_SIZE = 2;
-	//static const uint8_t _PAYLOAD_SIZE = _PACKET_SIZE - _HEADER_SIZE;
-	//static const uint8_t _HEADER_OFFSET = 48;
+	static const uint8_t _MAX_FRAGMENTS = 16;
+	static const uint8_t _PACKET_SIZE = 11;
+	static const uint8_t _HEADER_SIZE = 2;
+	static const uint8_t _PAYLOAD_SIZE = _PACKET_SIZE - _HEADER_SIZE;
+	static const uint8_t _HEADER_OFFSET = 48;
     
-	//static const uint8_t _MAX_PAIRS_SIZE = 100;
+	static const uint8_t _MAX_PAIRS_SIZE = 100;
     
-	//char _txBuffer[_MAX_FRAGMENTS][_PACKET_SIZE];
-	//uint8_t _txPutter = 0;
-	//uint8_t _txGetter = 0;
+	char _txBuffer[_MAX_FRAGMENTS][_PACKET_SIZE];
+	uint8_t _txPutter = 0;
+	uint8_t _txGetter = 0;
 	
 	static const uint8_t _MAX_MDOT_RESPONSE = 150;			//Max number of bytes the mdot might return
 	char _response[_MAX_MDOT_RESPONSE];						//mDot response buffer
@@ -85,9 +85,9 @@ class LoRaAT
 	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t);
 	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t, char**);             //Generic serial out get response wrapper
 	
-	//void _pairsToJSON(char*, char*);
-	//void _createFragmentBuffer(char*);
-	//int _processBuffer();
+	void _pairsToJSON(char*, char*);
+	void _createFragmentBuffer(char*);
+	int _processBuffer();
 	
     uint8_t _u8SerialPort;                                 //AT Command serial port selection by user
 	Stream* _debugStream;                                  //Debugging serial port initialized in constructor

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -23,11 +23,11 @@
 class LoRaAT
 {
   public:
-    char frequencySubBand = '\0';   //0-8
+    char networkKey[48] = {'\0'};	//00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01
+    char networkId[24] = {'\0'};    //00:00:aa:00:00:00:00:01
+	char frequencySubBand = '\0';   //0-8
 	char publicNetwork = '\0';		//0,1
-	char networkId[24] = {'\0'};    //00:00:aa:00:00:00:00:01
-	char networkKey[48] = {'\0'};	//00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01
-    char dataRate = '\0';			//0-3
+	char dataRate = '\0';			//0-3
 	
 	LoRaAT();				        //Use default serial port
 	LoRaAT(uint8_t);		        //Use specified serial port.
@@ -75,7 +75,7 @@ class LoRaAT
 	uint8_t _txPutter = 0;
 	uint8_t _txGetter = 0;
 	
-	static const uint8_t _MAX_MDOT_RESPONSE = 150;			//Max number of bytes the mdot might return
+	static const uint8_t _MAX_MDOT_RESPONSE = 200;			//Max number of bytes the mdot might return
 	char _response[_MAX_MDOT_RESPONSE];						//mDot response buffer
 	uint8_t _length;										//Lenght of a response
 	

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -89,8 +89,6 @@ class LoRaAT
 	//void _createFragmentBuffer(char*);
 	//int _processBuffer();
 	
-	bool _find(char*, char*, char*);
-	
     uint8_t _u8SerialPort;                                 //AT Command serial port selection by user
 	Stream* _debugStream;                                  //Debugging serial port initialized in constructor
 };

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -23,7 +23,12 @@
 class LoRaAT
 {
   public:
-    LoRaAT();				        //Use default serial port
+    char frequencySubBand = '\0';   //0-8
+	char publicNetwork = '\0';		//0,1
+	char networkId[23] = {'\0'};    //00:00:aa:00:00:00:00:01
+	char networkKey[47] = {'\0'};	//00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01
+    char dataRate = '\0';			//0-3
+	LoRaAT();				        //Use default serial port
 	LoRaAT(uint8_t);		        //Use specified serial port.
 	LoRaAT(uint8_t,Stream*);        //Use specified serial port and a debugging stream.
 	
@@ -50,7 +55,7 @@ class LoRaAT
     int getNetworkID();				//Also referred to as the AppEUI
     int setNetworkKey(char*);		//Also referred to as the AppKey
     int getNetworkKey();			//Also referred to as the AppKey
-    int setDataRate();
+    int setDataRate(char);
     int getDataRate();
     int setRXOutput(uint8_t);
     int getRXOutput();
@@ -69,7 +74,7 @@ class LoRaAT
 	uint8_t _txPutter = 0;
 	uint8_t _txGetter = 0;
 	
-	static const uint8_t _MAX_MDOT_RESPONSE = 120;			//Max number of bytes the mdot might return
+	static const uint8_t _MAX_MDOT_RESPONSE = 150;			//Max number of bytes the mdot might return
 	char _response[_MAX_MDOT_RESPONSE];						//mDot response buffer
 	uint8_t _length;										//Lenght of a response
 	

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -28,6 +28,7 @@ class LoRaAT
 	char networkId[24] = {'\0'};    //00:00:aa:00:00:00:00:01
 	char networkKey[48] = {'\0'};	//00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01
     char dataRate = '\0';			//0-3
+	
 	LoRaAT();				        //Use default serial port
 	LoRaAT(uint8_t);		        //Use specified serial port.
 	LoRaAT(uint8_t,Stream*);        //Use specified serial port and a debugging stream.
@@ -81,7 +82,8 @@ class LoRaAT
 	static const uint8_t _MAX_MDOT_COMMAND = 120;			//TODO: Check against the manual for mDot
 	char _command[_MAX_MDOT_COMMAND];
 	
-	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t);             //Generic serial out get response wrapper
+	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t);
+	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t, char*);             //Generic serial out get response wrapper
 	
 	void _pairsToJSON(char*, char*);
 	void _createFragmentBuffer(char*);

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -83,7 +83,7 @@ class LoRaAT
 	char _command[_MAX_MDOT_COMMAND];
 	
 	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t);
-	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t, char*);             //Generic serial out get response wrapper
+	uint8_t _sendCommand(char*, char*, char*, char*, char*, uint16_t, char**);             //Generic serial out get response wrapper
 	
 	//void _pairsToJSON(char*, char*);
 	//void _createFragmentBuffer(char*);

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -25,8 +25,8 @@ class LoRaAT
   public:
     char frequencySubBand = '\0';   //0-8
 	char publicNetwork = '\0';		//0,1
-	char networkId[23] = {'\0'};    //00:00:aa:00:00:00:00:01
-	char networkKey[47] = {'\0'};	//00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01
+	char networkId[24] = {'\0'};    //00:00:aa:00:00:00:00:01
+	char networkKey[48] = {'\0'};	//00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01
     char dataRate = '\0';			//0-3
 	LoRaAT();				        //Use default serial port
 	LoRaAT(uint8_t);		        //Use specified serial port.

--- a/LoRaAT/LoRaAT.h
+++ b/LoRaAT/LoRaAT.h
@@ -52,7 +52,7 @@ class LoRaAT
     int getNetworkKey();			//Also referred to as the AppKey
     int setDataRate();
     int getDataRate();
-    int setRXOutput();
+    int setRXOutput(uint8_t);
     int getRXOutput();
     int commitSettings();			//Not yet implemented
   

--- a/LoRaAT/examples/Edit_Settings/Edit_Settings.ino
+++ b/LoRaAT/examples/Edit_Settings/Edit_Settings.ino
@@ -1,10 +1,10 @@
 /*
- This is a test program writen for the Seeeduino Stalker v2.3 and 
- uses the Multitech mDOT LoRa module running the Australian compatable AT
- enabled firmware.
- 
- This program,
-  * Gets and sets settings on the mDot
+  This is a test program writen for the Seeeduino Stalker v2.3 and
+  uses the Multitech mDOT LoRa module running the Australian compatable AT
+  enabled firmware.
+
+  This program,
+    Gets and sets settings on the mDot
 */
 
 /*--------------------------------------------------------------------------------------
@@ -32,11 +32,22 @@ LoRaAT mdot(0, &debugSerial);           //Instantiate a LoRaAT object
   --------------------------------------------------------------------------------------*/
 void setup() {
   int responseCode;
-  
+
   debugSerial.begin(38400);             //Debug output. Listen on this ports for debugging info
   mdot.begin(38400);                    //Begin (possibly amongst other things) opens serial comms with MDOT
-  
+
   debugSerial.println("\r\n\r\n++ START ++\r\n\r\n");
+
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.frequencySubBand);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.publicNetwork);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.networkId);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.networkKey);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.dataRate);
 
   //Get all the initial settings
   mdot.getFrequencySubBand();
@@ -44,24 +55,56 @@ void setup() {
   mdot.getNetworkID();
   mdot.getNetworkKey();
   mdot.getDataRate();
-  mdot.getRXOutput();
+
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.frequencySubBand);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.publicNetwork);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.networkId);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.networkKey);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.dataRate);
 
   //Set some settings
   mdot.setFrequencySubBand('2');
   mdot.setPublicNetwork('1');
-  char id[] = "00:00:aa:00:00:00:00:01";
+  char id[] = "00:00:bb:00:00:00:00:01";
   mdot.setNetworkID(id);
   char key[] = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01";
   mdot.setNetworkKey(key);
-  
+  mdot.setDataRate('3');
+
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.frequencySubBand);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.publicNetwork);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.networkId);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.networkKey);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.dataRate);
+
   //Get the settings
   mdot.getFrequencySubBand();
   mdot.getPublicNetwork();
   mdot.getNetworkID();
   mdot.getNetworkKey();
   mdot.getDataRate();
-  mdot.getRXOutput();
-  
+
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.frequencySubBand);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.publicNetwork);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.networkId);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.networkKey);
+  debugSerial.print(F("SETUP : "));
+  debugSerial.println(mdot.dataRate);
+
   //Set to defaults
 
   //Get the settings

--- a/LoRaAT/examples/Send_Data/Send_Data.ino
+++ b/LoRaAT/examples/Send_Data/Send_Data.ino
@@ -60,16 +60,16 @@ void loop() {
   String testMessage = "";  //Test message sent via debugSerial
   
   //Build the message to send:
-  String rtcTemp = F("RTC Temp:");
+  String rtcTemp = F("Temp1:");
   testMessage = rtcTemp;
   RTC.convertTemperature(); //convert current temperature into registers
   testMessage += RTC.getTemperature();
 
-  String atTemp = F("ATmega328P Temp:");
+  String atTemp = F(",Temp2:");
   testMessage += atTemp;
   testMessage += GetTemp();
   
-  String count = F(",Loop Count:");
+  String count = F(",Loop:");
   testMessage += count;
   testMessage += loopNum;
 


### PR DESCRIPTION
The getters and setters now work, there is a BUG in the get and set for the network key. It seems like the mDot returns a NULL between the O and K causing the _sendCommand function to exit due to a NULL rather than OK. Therefore returning (arguably) the wrong answer code.

As a workaround it looks for something other than NULL in the response.

It doesn't seem to be a stack or memory issue, because rearranging the stack size, and memory allocation doesn't change the way it fails AT-ALL.

Does the mDot actually (and consistently) return a NULL between the O and K when the AT+NK[insert anything valid here] command is called?
